### PR TITLE
chore: gitignore .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ CLAUDE.md
 # Serena MCP Server
 .serena/
 
+# MCP config (may reference secrets via env)
+.mcp.json
+
 # user-requested ignore
 AGENTS.md


### PR DESCRIPTION
## Summary
- `.mcp.json` を `.gitignore` に追加し、MCP 設定ファイル（env 経由で秘密情報を参照）の誤コミットを防止

## Test plan
- [x] `git check-ignore -v .mcp.json` で無視対象になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)