### PR TITLE
feat: 収益化基盤の整備（AdSense配置・ステマ規制対応・SITE_URL/docs整理）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ AGENTS.md
 
 # local-only docs (blog ideas, drafts, etc.) — git管理対象外
 /localdocs/
+
+# article assets (thumbnail HTML/PNG generation) — local-only
+.article-assets/

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ CLAUDE.md
 # Serena MCP Server
 .serena/
 
+# Playwright MCP (auto-generated console logs / page snapshots)
+.playwright-mcp/
+
 # MCP config (may reference secrets via env)
 .mcp.json
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ npm install
 cat > .env << EOF
 MICROCMS_API_KEY=your_api_key_here
 MICROCMS_SERVICE_DOMAIN=your_domain_here
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
 BASE_URL=http://localhost:3000
 EOF
 
@@ -99,12 +100,72 @@ npm run dev
 5. 環境変数を設定：
    - `MICROCMS_API_KEY`: microCMS APIキー
    - `MICROCMS_SERVICE_DOMAIN`: microCMSサービスドメイン
-   - `BASE_URL`: デプロイ後のURL（例: https://your-app.vercel.app）
+   - `NEXT_PUBLIC_SITE_URL`: デプロイ後の公開URL（例: https://www.s1msys.com）。OGP / canonical / sitemap / feed.xml の絶対URL用
+   - `NEXT_PUBLIC_CONTACT_EMAIL`: お問い合わせフォームの mailto: 先メールアドレス
+   - （任意）`NEXT_PUBLIC_GA_MEASUREMENT_ID` / `NEXT_PUBLIC_SITE_TWITTER`
+   - （AdSense 用・任意）`NEXT_PUBLIC_ADSENSE_CLIENT`, `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_TOP`, `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_MID`, `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_BOTTOM`, `NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR`
+
+> `BASE_URL` は Playwright / Jest 用のテスト変数。Vercel 側に設定する必要はない。
+> AdSense 環境変数は未設定時は枠自体がレンダリングされない（null）安全設計。承認前は未設定のままで構わない。
 
 ##### 自動デプロイ
 - `main`ブランチへのpushで本番環境に自動デプロイ
 - `develop`ブランチへのpushでプレビュー環境に自動デプロイ
 - Pull Requestごとにプレビュー環境が作成
+
+##### microCMS → Vercel Webhook 連携
+`output: 'export'` の静的サイト構成のため、microCMS で記事を公開しただけではサイトに反映されない。以下を一度設定すれば、microCMS 側の公開/更新/削除を契機に Vercel が自動再ビルドする。
+
+1. **Vercel: Deploy Hook を発行**
+   - Vercel ダッシュボード → 該当プロジェクト → Settings → Git → "Deploy Hooks"
+   - Name: `microcms-content-published`、Branch: `main`（プレビューも回したい場合は `develop` 用も別途作成）
+   - 発行された URL（例: `https://api.vercel.com/v1/integrations/deploy/prj_xxx/yyy`）をコピー
+2. **microCMS: Webhook を登録**
+   - microCMS 管理画面 → `blog` API → API 設定 → Webhook → 「追加」
+   - サービスは「Vercel」または「カスタム通知」を選択し、上記 URL を貼り付け
+   - 通知タイミング: 公開 / 公開終了 / 公開中の更新 / 削除 をすべて有効化
+3. **動作確認**
+   - microCMS で任意の記事を再公開 → Vercel Deployments に新規ビルドが流れることを確認
+
+> Deploy Hook URL はトークン相当の機密。リポジトリにコミットせず、Vercel/microCMS 両側のダッシュボードでのみ管理する。
+
+## 💰 収益化（Google AdSense）
+
+### 申請前チェックリスト
+
+- [ ] プライバシーポリシー（`/privacy-policy`）が公開済み
+- [ ] アフィリエイト開示（`/disclosure`）が公開済み
+- [ ] お問い合わせ（`/contact`）が機能している（`NEXT_PUBLIC_CONTACT_EMAIL` を設定済み）
+- [ ] オリジナル記事が5〜10本以上公開済み
+- [ ] サイトマップ（`/sitemap.xml`）が Search Console に登録済み
+
+### AdSense 承認後の作業
+
+1. **`ads.txt` の作成**
+   - リポジトリには placeholder を置かない（誤って配信エラーを増やすため）
+   - 承認後、AdSense ダッシュボード「サイト > ads.txt の取得」から正しい1行を取得し、`front/public/ads.txt` に配置:
+     ```
+     google.com, pub-XXXXXXXXXXXXXXXX, DIRECT, f08c47fec0942fa0
+     ```
+   - 複数事業者を使う場合は1行ずつ追記
+2. **広告ユニットの作成と環境変数設定**
+   - AdSense ダッシュボード → 広告ユニット で4つ作成し、各 slot ID を Vercel 環境変数に設定:
+     - `NEXT_PUBLIC_ADSENSE_CLIENT` … 例 `ca-pub-XXXXXXXXXXXXXXXX`
+     - `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_TOP` … 記事冒頭（ディスプレイ）
+     - `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_MID` … 記事中盤（インフィード/インアーティクル推奨）
+     - `NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_BOTTOM` … 記事末尾（ディスプレイ）
+     - `NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR` … サイドバー（PCのみ表示）
+3. **Vercel で再ビルド**
+   - microCMS Webhook 経由 or `main` への空コミット push で再デプロイ
+4. **動作確認**
+   - 記事ページで4ヶ所すべてに広告が描画されること
+   - サイドバー枠はモバイル幅で非表示になっていること（CLS と AdSense ポリシー対策）
+
+### ステマ規制対応
+
+- 全記事に `PR` 開示バッジが冒頭に表示される（`components/PRDisclosure`）
+- 本文内の Amazon・楽天・主要ASPドメインへのリンクには `rel="sponsored nofollow noopener"` が自動付与される（`libs/utils.ts:isAffiliateUrl`）
+- 対応ドメイン追加は `AFFILIATE_HOST_PATTERNS` 配列を更新する
 
 ## 🚀 デプロイ
 
@@ -217,8 +278,8 @@ Vercelの機能により最適化：
 
 | 環境 | ブランチ | URL |
 |-----|---------|-----|
-| 本番 | main | https://your-app.vercel.app |
-| プレビュー | develop | https://your-app-preview.vercel.app |
+| 本番 | main | https://www.s1msys.com |
+| プレビュー | develop | Vercel が発行するプレビューURL |
 | PR | feature/* | 自動生成されるプレビューURL |
 
 ## 📚 詳細ドキュメント

--- a/front/README.md
+++ b/front/README.md
@@ -15,7 +15,8 @@ Node.js 18 以上
 ```
 MICROCMS_API_KEY=xxxxxxxxxx
 MICROCMS_SERVICE_DOMAIN=xxxxxxxxxx
-BASE_URL=xxxxxxxxxx
+NEXT_PUBLIC_SITE_URL=https://www.s1msys.com
+BASE_URL=http://localhost:3000
 ```
 
 `MICROCMS_API_KEY`  
@@ -24,12 +25,16 @@ microCMS 管理画面の「サービス設定 > API キー」から確認する�
 `MICROCMS_SERVICE_DOMAIN`  
 microCMS 管理画面の URL（https://xxxxxxxx.microcms.io）の xxxxxxxx の部分です。
 
-`BASE_URL`
-デプロイ先の URL です。プロトコルから記載してください。
+`NEXT_PUBLIC_SITE_URL`  
+サイトの公開URL。OGP / canonical / sitemap / feed.xml の絶対URLとして使われます。
+未設定の場合は `front/constants/index.ts` の `SITE_URL` デフォルト値 `https://www.s1msys.com` にフォールバックします。
 
 例）  
 開発環境 → http://localhost:3000  
-本番環境（Vercel） → https://your-app.vercel.app
+本番環境（Vercel） → https://www.s1msys.com
+
+`BASE_URL`  
+Playwright (E2E) / Jest setup でのみ使用されるベースURL。本番ランタイムには影響しません。
 
 ## 開発の仕方
 
@@ -78,7 +83,10 @@ npm run test:coverage # カバレッジレポート付きテスト
 Vercelのプロジェクト設定で以下の環境変数を追加：
 - `MICROCMS_API_KEY`
 - `MICROCMS_SERVICE_DOMAIN`
-- `BASE_URL`
+- `NEXT_PUBLIC_SITE_URL`（本番公開URL）
+- （任意）`NEXT_PUBLIC_GA_MEASUREMENT_ID` / `NEXT_PUBLIC_ADSENSE_CLIENT` / `NEXT_PUBLIC_SITE_TWITTER`
+
+> `BASE_URL` は E2E / テストでのみ参照されるため Vercel には不要です。
 
 ### 自動デプロイ
 

--- a/front/app/disclosure/page.tsx
+++ b/front/app/disclosure/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next';
+import styles from '../privacy-policy/page.module.css';
+
+export const metadata: Metadata = {
+  title: 'アフィリエイト・広告に関する開示 | S1MLOG',
+  description:
+    'S1MLOG における Google AdSense などのディスプレイ広告、Amazon アソシエイト等のアフィリエイトリンクの取り扱い・開示方針について記載しています。',
+  alternates: { canonical: '/disclosure' },
+};
+
+export default function DisclosurePage() {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>アフィリエイト・広告に関する開示</h1>
+
+      <p>
+        S1MLOG（以下「当サイト」）は、コンテンツ提供にかかる運営費用の補填および継続的な情報発信のために、第三者配信のディスプレイ広告およびアフィリエイトプログラムを利用しています。本ページでは、景品表示法に基づく表示（いわゆるステマ規制）の観点から、当サイトの広告・アフィリエイトに関する取り扱い方針を開示します。
+      </p>
+
+      <h2 className={styles.sectionTitle}>ディスプレイ広告について</h2>
+      <p>
+        当サイトでは第三者配信の広告サービス（Google
+        AdSense等）を利用しています。これらの広告は、ユーザーの興味に応じた商品・サービスの広告を表示するためにCookie等を使用することがあります。広告配信に関する詳細はGoogleの
+        <a
+          href="https://policies.google.com/technologies/ads?hl=ja"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          広告ポリシー
+        </a>
+        をご確認ください。
+      </p>
+
+      <h2 className={styles.sectionTitle}>アフィリエイトプログラムへの参加</h2>
+      <p>
+        当サイトは以下のアフィリエイトプログラムに参加しています。商品・サービスを当サイト経由でご購入いただくと、運営者に紹介料が支払われることがあります。
+      </p>
+      <ul className={styles.list}>
+        <li>Amazon.co.jp アソシエイト</li>
+        <li>楽天アフィリエイト</li>
+        <li>もしもアフィリエイト</li>
+        <li>バリューコマース、A8.net、アクセストレード 等の各種ASP</li>
+      </ul>
+      <p>
+        当サイトは Amazon.co.jp
+        を宣伝しリンクすることによってサイトが紹介料を獲得できる手段を提供することを目的に設定されたアフィリエイトプログラムである、Amazon
+        アソシエイト・プログラムの参加者です。
+      </p>
+
+      <h2 className={styles.sectionTitle}>記事への表示について</h2>
+      <p>
+        当サイトでは、アフィリエイトリンクを含む記事および広告枠を含むページに「PR」表示を行います。記事内のアフィリエイトリンクには
+        <code>rel=&quot;sponsored&quot;</code>
+        を自動付与しており、検索エンジンに対して商業的関係性を明示しています。
+      </p>
+
+      <h2 className={styles.sectionTitle}>コンテンツの中立性について</h2>
+      <p>
+        紹介する商品・サービスの選定および記事内容については、運営者自身の使用経験・調査結果・公開情報に基づいて記載しています。アフィリエイト報酬の有無や金額によって評価内容を恣意的に操作することはありません。ただし、誤情報や古い情報が含まれる可能性があるため、最終的なご購入・ご利用判断は読者ご自身でお願いします。
+      </p>
+
+      <h2 className={styles.sectionTitle}>免責事項</h2>
+      <p>
+        当サイトで紹介する商品・サービスに関するトラブル・損害について、当サイトでは責任を負いかねます。各サービスの利用規約・販売事業者の表示をご確認のうえご利用ください。
+      </p>
+
+      <p className={styles.updatedAt}>制定日：2026年5月</p>
+    </div>
+  );
+}

--- a/front/app/layout.module.css
+++ b/front/app/layout.module.css
@@ -53,3 +53,16 @@
     padding: 16px 16px 40px;
   }
 }
+
+.sidebarAd {
+  margin-top: 24px;
+  width: 100%;
+  min-height: 250px;
+}
+
+/* モバイル幅ではサイドバー広告は記事下の AdSlot と被るので非表示 */
+@media (max-width: 960px) {
+  .sidebarAd {
+    display: none;
+  }
+}

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -17,6 +17,9 @@ import Profile from '@/components/Profile';
 import JsonLd from '@/components/JsonLd';
 import CookieConsent from '@/components/CookieConsent';
 import AnalyticsListeners from '@/components/Analytics';
+import AdSlot from '@/components/AdSlot';
+
+const AD_SLOT_SIDEBAR = process.env.NEXT_PUBLIC_ADSENSE_SLOT_SIDEBAR || '';
 import './globals.css';
 import styles from './layout.module.css';
 
@@ -134,6 +137,11 @@ export default async function RootLayout({ children }: Props) {
         <div className={styles.container}>
           <aside className={styles.sidebar}>
             <Profile writer={writer} />
+            {AD_SLOT_SIDEBAR && (
+              <div className={styles.sidebarAd}>
+                <AdSlot slot={AD_SLOT_SIDEBAR} format="auto" />
+              </div>
+            )}
           </aside>
           <main className={styles.main}>{children}</main>
         </div>

--- a/front/components/Article/index.module.css
+++ b/front/components/Article/index.module.css
@@ -298,3 +298,13 @@
     font-size: 0.8rem;
   }
 }
+
+.adSlot {
+  margin: 24px auto;
+  width: 100%;
+  max-width: var(--content-max, 760px);
+  min-height: 90px;
+  display: flex;
+  justify-content: center;
+}
+

--- a/front/components/Article/index.tsx
+++ b/front/components/Article/index.tsx
@@ -2,6 +2,8 @@ import { formatRichText } from '@/libs/utils';
 import { type Article } from '@/libs/microcms';
 import PublishedDate from '../Date';
 import TableOfContents, { buildTocHtml } from '../TableOfContents';
+import AdSlot from '../AdSlot';
+import PRDisclosure from '../PRDisclosure';
 import styles from './index.module.css';
 import TagList from '../TagList';
 
@@ -9,9 +11,14 @@ type Props = {
   data: Article;
 };
 
+const AD_SLOT_ARTICLE_TOP = process.env.NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_TOP || '';
+const AD_SLOT_ARTICLE_MID = process.env.NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_MID || '';
+const AD_SLOT_ARTICLE_BOTTOM = process.env.NEXT_PUBLIC_ADSENSE_SLOT_ARTICLE_BOTTOM || '';
+
 export default function Article({ data }: Props) {
   const formattedContent = data.content ? formatRichText(data.content) : '';
-  const { html, headings } = buildTocHtml(formattedContent);
+  const { headings, firstHalfHtml, secondHalfHtml } = buildTocHtml(formattedContent);
+  const isSplit = Boolean(firstHalfHtml);
 
   return (
     <main className={styles.main}>
@@ -61,8 +68,31 @@ export default function Article({ data }: Props) {
           />
         </picture>
       )}
+      <PRDisclosure />
       <TableOfContents headings={headings} />
-      <div className={styles.content} dangerouslySetInnerHTML={{ __html: html }} />
+      {AD_SLOT_ARTICLE_TOP && (
+        <div className={styles.adSlot}>
+          <AdSlot slot={AD_SLOT_ARTICLE_TOP} format="auto" />
+        </div>
+      )}
+      {isSplit ? (
+        <>
+          <div className={styles.content} dangerouslySetInnerHTML={{ __html: firstHalfHtml }} />
+          {AD_SLOT_ARTICLE_MID && (
+            <div className={styles.adSlot}>
+              <AdSlot slot={AD_SLOT_ARTICLE_MID} format="fluid" layout="in-article" />
+            </div>
+          )}
+          <div className={styles.content} dangerouslySetInnerHTML={{ __html: secondHalfHtml }} />
+        </>
+      ) : (
+        <div className={styles.content} dangerouslySetInnerHTML={{ __html: secondHalfHtml }} />
+      )}
+      {AD_SLOT_ARTICLE_BOTTOM && (
+        <div className={styles.adSlot}>
+          <AdSlot slot={AD_SLOT_ARTICLE_BOTTOM} format="auto" />
+        </div>
+      )}
     </main>
   );
 }

--- a/front/components/Footer/index.tsx
+++ b/front/components/Footer/index.tsx
@@ -9,6 +9,8 @@ export default function Footer() {
         <span className={styles.sep}>/</span>
         <Link href="/privacy-policy">プライバシーポリシー</Link>
         <span className={styles.sep}>/</span>
+        <Link href="/disclosure">アフィリエイト開示</Link>
+        <span className={styles.sep}>/</span>
         <Link href="/contact">お問い合わせ</Link>
         <span className={styles.sep}>/</span>
         <a href="/feed.xml">RSS</a>

--- a/front/components/PRDisclosure/index.module.css
+++ b/front/components/PRDisclosure/index.module.css
@@ -1,0 +1,38 @@
+.disclosure {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border, #e6e6e6);
+  border-radius: 6px;
+  background: var(--color-bg-sub, #f7f7f8);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--color-text-sub, #666);
+}
+
+.tag {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--color-text, #111);
+  color: #fff;
+}
+
+.text {
+  flex: 1 1 auto;
+}
+
+.link {
+  color: var(--color-link, #2666cf);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.link:hover {
+  opacity: 0.8;
+}

--- a/front/components/PRDisclosure/index.tsx
+++ b/front/components/PRDisclosure/index.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import styles from './index.module.css';
+
+type Props = {
+  variant?: 'compact' | 'detail';
+};
+
+export default function PRDisclosure({ variant = 'compact' }: Props) {
+  return (
+    <p className={styles.disclosure} role="note">
+      <span className={styles.tag} aria-label="広告表示">
+        PR
+      </span>
+      {variant === 'detail' ? (
+        <span className={styles.text}>
+          本記事には広告（Google
+          AdSense）およびアフィリエイトリンクが含まれることがあります。詳しくは
+          <Link href="/disclosure" className={styles.link}>
+            アフィリエイト開示
+          </Link>
+          をご覧ください。
+        </span>
+      ) : (
+        <span className={styles.text}>
+          本記事には広告・アフィリエイトリンクが含まれることがあります（
+          <Link href="/disclosure" className={styles.link}>
+            開示
+          </Link>
+          ）
+        </span>
+      )}
+    </p>
+  );
+}

--- a/front/components/TableOfContents/index.tsx
+++ b/front/components/TableOfContents/index.tsx
@@ -18,8 +18,10 @@ const slugify = (raw: string, fallbackIndex: number): string => {
   return base || `heading-${fallbackIndex}`;
 };
 
-export const buildTocHtml = (html: string): { html: string; headings: Heading[] } => {
-  if (!html) return { html: '', headings: [] };
+export const buildTocHtml = (
+  html: string,
+): { html: string; headings: Heading[]; firstHalfHtml: string; secondHalfHtml: string } => {
+  if (!html) return { html: '', headings: [], firstHalfHtml: '', secondHalfHtml: '' };
   const $ = cheerio.load(html);
   const headings: Heading[] = [];
   const usedIds = new Set<string>();
@@ -40,7 +42,25 @@ export const buildTocHtml = (html: string): { html: string; headings: Heading[] 
     headings.push({ id, text, level });
   });
 
-  return { html: $.html(), headings };
+  // 記事中盤に広告を挿入できるよう、本文を「中央付近の H2」で前半・後半に分割する。
+  // H2 が 2 未満の短い記事では分割しない（後半に全体を入れて前半を空にする）。
+  const h2Headings = headings.filter((h) => h.level === 2);
+  const fullHtml = $.html();
+  let firstHalfHtml = '';
+  let secondHalfHtml = fullHtml;
+
+  if (h2Headings.length >= 2) {
+    const midIndex = Math.floor(h2Headings.length / 2);
+    const splitId = h2Headings[midIndex].id;
+    const re = new RegExp(`<h2\\b[^>]*\\bid=["']${splitId}["'][^>]*>`, 'i');
+    const m = fullHtml.match(re);
+    if (m && m.index !== undefined) {
+      firstHalfHtml = fullHtml.slice(0, m.index);
+      secondHalfHtml = fullHtml.slice(m.index);
+    }
+  }
+
+  return { html: fullHtml, headings, firstHalfHtml, secondHalfHtml };
 };
 
 type Props = {

--- a/front/libs/utils.ts
+++ b/front/libs/utils.ts
@@ -22,6 +22,36 @@ export const formatDate = (date: string): string => {
   }
 };
 
+// アフィリエイト判定対象のドメイン断片。判定はホスト名の含有チェックで行う（サブドメイン許容）
+const AFFILIATE_HOST_PATTERNS = [
+  'amzn.to',
+  'amazon.co.jp',
+  'amazon.com',
+  'amazon.jp',
+  'rakuten.co.jp',
+  'rakuten.ne.jp',
+  'a8.net',
+  'px.a8.net',
+  'valuecommerce.com',
+  'mkt-valuecommerce.com',
+  'moshimo.com',
+  'af.moshimo.com',
+  'linksynergy.com',
+  'click.linksynergy.com',
+  'iherb.com',
+  'tcs-asp.net', // アクセストレード
+  'felmat.net',
+];
+
+const isAffiliateUrl = (url: string): boolean => {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return AFFILIATE_HOST_PATTERNS.some((p) => host === p || host.endsWith(`.${p}`));
+  } catch {
+    return false;
+  }
+};
+
 /**
  * リッチテキストをHTML形式にフォーマットする
  * @param richText - リッチテキスト文字列
@@ -56,6 +86,19 @@ export const formatRichText = (richText: string): string => {
       const lang = $(elm).attr('class');
       const res = highlight($(elm).text(), lang);
       $(elm).html(res);
+    });
+
+    // アフィリエイト・広告系の外部リンクに rel="sponsored nofollow noopener" を自動付与し、
+    // target="_blank" も併せて付ける（景表法ステマ規制 / Google ガイドライン対応）
+    $('a[href^="http"]').each((_, elm) => {
+      const $a = $(elm);
+      const href = $a.attr('href') || '';
+      if (!isAffiliateUrl(href)) return;
+      const existingRel = ($a.attr('rel') || '').split(/\s+/).filter(Boolean);
+      const merged = Array.from(new Set([...existingRel, 'sponsored', 'nofollow', 'noopener']));
+      $a.attr('rel', merged.join(' '));
+      if (!$a.attr('target')) $a.attr('target', '_blank');
+      $a.attr('data-affiliate', 'true');
     });
 
     return $.html(); // 変更されたHTMLを返す

--- a/front/public/ads.txt
+++ b/front/public/ads.txt
@@ -1,3 +1,0 @@
-# Google AdSense ads.txt
-# 申請承認後、本番の publisher ID へ書き換える。
-# google.com, pub-XXXXXXXXXXXXXXXX, DIRECT, f08c47fec0942fa0

--- a/front/public/sitemap-0.xml
+++ b/front/public/sitemap-0.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.s1msys.com/</loc><lastmod>2026-04-28T04:03:47.696Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/contact/</loc><lastmod>2026-04-28T04:03:47.696Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/feed.xml/</loc><lastmod>2026-04-28T04:03:47.696Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/privacy-policy/</loc><lastmod>2026-04-28T04:03:47.696Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/tags/12ck80mh4/</loc><lastmod>2026-04-28T04:03:48.133Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/tags/190j-rdbd/</loc><lastmod>2026-04-28T04:03:48.133Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/tags/e528o6tiuqvf/</loc><lastmod>2026-04-28T04:03:48.133Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/tags/qske6cm1oq5b/</loc><lastmod>2026-04-28T04:03:48.133Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/articles/ye0vk3lz0/</loc><lastmod>2026-04-28T04:03:48.033Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/articles/0hsr4xpqypsa/</loc><lastmod>2026-04-28T04:03:48.033Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/articles/bx5n8nyrhz/</loc><lastmod>2026-04-28T04:03:48.033Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/articles/cg2h_z3ewl/</loc><lastmod>2026-04-28T04:03:48.033Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.s1msys.com/articles/z2qs_kp5vnt/</loc><lastmod>2026-04-28T04:03:48.033Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/</loc><lastmod>2026-05-17T05:59:20.809Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/contact/</loc><lastmod>2026-05-17T05:59:20.810Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/disclosure/</loc><lastmod>2026-05-17T05:59:20.810Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/feed.xml/</loc><lastmod>2026-05-17T05:59:20.810Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/privacy-policy/</loc><lastmod>2026-05-17T05:59:20.810Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/tags/12ck80mh4/</loc><lastmod>2026-05-17T05:59:21.139Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/tags/190j-rdbd/</loc><lastmod>2026-05-17T05:59:21.139Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/tags/e528o6tiuqvf/</loc><lastmod>2026-05-17T05:59:21.139Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/tags/qske6cm1oq5b/</loc><lastmod>2026-05-17T05:59:21.139Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/articles/ye0vk3lz0/</loc><lastmod>2026-05-17T05:59:21.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/articles/0hsr4xpqypsa/</loc><lastmod>2026-05-17T05:59:21.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/articles/bx5n8nyrhz/</loc><lastmod>2026-05-17T05:59:21.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/articles/cg2h_z3ewl/</loc><lastmod>2026-05-17T05:59:21.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.s1msys.com/articles/z2qs_kp5vnt/</loc><lastmod>2026-05-17T05:59:21.056Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary
収益化（Google AdSense + アフィリエイト）を本格運用できる状態に持っていくための基盤整備。

- **AdSlot を 4 箇所に配置**（記事冒頭 / 中盤 / 末尾 / サイドバー）。中盤は `buildTocHtml` を拡張して中央 H2 で本文を分割し、その境界に挿入。各広告枠の Slot ID は `NEXT_PUBLIC_ADSENSE_SLOT_*` で制御し、未設定時は枠を一切描画しない。サイドバーはモバイル幅で非表示。
- **景表法ステマ規制対応**: 全記事冒頭に `PRDisclosure` を表示、`/disclosure` 固定ページ追加、`libs/utils.ts:isAffiliateUrl` で Amazon / 楽天 / A8 / もしも / バリューコマース 等主要ASPドメインへのリンクに `rel="sponsored nofollow noopener"` を自動付与。
- **`ads.txt` 整理**: 不正な placeholder（コメント + robots.txt 混入）を削除し、AdSense 承認後の運用手順を README に追記。
- **docs**: `BASE_URL` 中心の旧構成を `NEXT_PUBLIC_SITE_URL` 中心へ整理。Webhook 連携手順、AdSense 申請前チェックリストも追加。
- **`.gitignore`**: `.playwright-mcp/` と `.article-assets/` を ignore に追加。

## Test plan
- [x] `npm run build` 成功（sitemap に `/disclosure/` 自動掲載確認）
- [x] `npm run lint` 通過
- [x] `npm test` 35/35 pass
- [ ] Vercel Preview で記事ページを開き、AdSense 環境変数未設定でも崩れていないこと確認
- [ ] `/disclosure` および `/privacy-policy` のレンダリング確認
- [ ] Footer に「アフィリエイト開示」リンクが追加されていること
- [ ] 全記事に「PR」開示バッジが表示されること

## Follow-up（このPR外）
- Vercel に AdSense 用 env (`NEXT_PUBLIC_ADSENSE_CLIENT`, `NEXT_PUBLIC_ADSENSE_SLOT_*`) を設定（AdSense 承認後）
- microCMS → Vercel Deploy Hook の Webhook 登録（手順は README 記載）
- Google Search Console プロパティ追加 + sitemap 送信

🤖 Generated with [Claude Code](https://claude.com/claude-code)