### PR TITLE
fix(microcms): 下書き記事の本番一覧露出を防ぐ（publishedAt[exists] フィルタ）

### DIFF
--- a/front/libs/__tests__/microcms.test.ts
+++ b/front/libs/__tests__/microcms.test.ts
@@ -54,7 +54,7 @@ describe('microCMS API', () => {
 
       expect(mockClient.getList).toHaveBeenCalledWith({
         endpoint: 'blog',
-        queries: undefined,
+        queries: { filters: 'publishedAt[exists]' },
       });
       expect(result).toEqual(mockData);
     });
@@ -68,7 +68,20 @@ describe('microCMS API', () => {
 
       expect(mockClient.getList).toHaveBeenCalledWith({
         endpoint: 'blog',
-        queries,
+        queries: { ...queries, filters: 'publishedAt[exists]' },
+      });
+    });
+
+    it('ユーザー指定の filters は publishedAt[exists] と AND 結合される', async () => {
+      const queries = { filters: 'tags[contains]tag1' };
+      const mockClient = getMockClient();
+      mockClient.getList.mockResolvedValue({ contents: [] });
+
+      await getList(queries);
+
+      expect(mockClient.getList).toHaveBeenCalledWith({
+        endpoint: 'blog',
+        queries: { filters: 'publishedAt[exists][and]tags[contains]tag1' },
       });
     });
 

--- a/front/libs/microcms.ts
+++ b/front/libs/microcms.ts
@@ -58,6 +58,13 @@ export const client = isValidConfig
       apiKey: 'dummy',
     });
 
+// 下書きを除外するための microCMS フィルタ。publishedAt が存在するもののみ返す。
+// 現状の API キーは権限上下書きも返してしまうため、フロント側で明示的に弾く必要がある。
+const PUBLISHED_FILTER = 'publishedAt[exists]';
+
+const mergeWithPublishedFilter = (userFilters?: string): string =>
+  userFilters ? `${PUBLISHED_FILTER}[and]${userFilters}` : PUBLISHED_FILTER;
+
 // ブログ一覧を取得
 export const getList = async (queries?: MicroCMSQueries) => {
   // APIキーが設定されていない場合は空のデータを返す
@@ -73,7 +80,7 @@ export const getList = async (queries?: MicroCMSQueries) => {
   try {
     const listData = await client.getList<Blog>({
       endpoint: 'blog',
-      queries,
+      queries: { ...queries, filters: mergeWithPublishedFilter(queries?.filters) },
     });
     return listData;
   } catch (error) {


### PR DESCRIPTION
## Summary
- microCMS API キーの権限上、下書きも一覧 API で返ってきてしまい本番のトップに混入する事象への根本対策
- `getList()` のクエリにデフォルトで `publishedAt[exists]` を付与し、公開済みのみを返す
- ユーザー指定の `filters` は `[and]` で AND 結合し、タグ絞り込み等の既存フィルタを壊さない

## 背景
- 直近、本番一覧に下書き想定の記事 (`x_d_41x9om2`) が露出。Vercel 反映済み
- API キーを絞ることでも対処可能だが、フロント側に防御線を持つことで multi-source の事故耐性を上げる

## 変更点
- `front/libs/microcms.ts`
  - `PUBLISHED_FILTER = 'publishedAt[exists]'` 定数を追加
  - `mergeWithPublishedFilter()` でユーザー filters と AND 結合
  - `getList()` の `client.getList` 呼び出しに常時付与
- `front/libs/__tests__/microcms.test.ts`
  - 既存テストを新挙動に合わせて更新
  - ユーザー指定 filters との AND 結合を検証するケースを追加

## 既知の残課題（このPRの範囲外）
- sitemap (`front/public/sitemap-0.xml`) には依然として `x_d_41x9om2` が混入していた。これは microCMS 側で当該記事に `publishedAt` が残っているケース（過去に一度公開済み等）の可能性が高い
- このPRマージ→Vercel 再ビルド後、sitemap から落ちなければ microCMS 側で当該記事を削除 or `publishedAt` を空にするオペレーションが必要

## Test plan
- [x] `npm run lint`
- [x] `npm run test`（36 件全て成功）
- [x] `npm run build`
- [ ] マージ→Vercel 自動デプロイ後、本番トップから下書きが消えていることを確認
- [ ] sitemap-0.xml に `x_d_41x9om2` が残っていないかを確認（残っていれば microCMS 側オペレーションへ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)