### PR TITLE
chore(deps): 上流未対応の eslint 10 / typescript 7 を dependabot の対象外にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,18 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # eslint 10 は eslint-config-next が同梱する eslint-plugin-react 7.37.5 が未対応。
+      # eslint 10 で削除された context.getFilename() を呼ぶため、rule の読み込み時点で落ちる。
+      # eslint-plugin-react の peerDependencies に eslint 10 が入ったら、この ignore を外す。
+      - dependency-name: eslint
+        versions:
+          - '>=10'
+      # typescript 7 は @typescript-eslint 8.x の peer が typescript <6.1.0 のため npm ci が解決できない。
+      # typescript-eslint が typescript 7 対応版（peer 緩和）を出したら、この ignore を外す。
+      - dependency-name: typescript
+        versions:
+          - '>=7'
 
   # ci.yml で使う actions/checkout・setup-node 等のバージョン更新
   - package-ecosystem: github-actions


### PR DESCRIPTION
## 背景

Dependabot の PR が 8 本溜まっていたので棚卸しした。e2e が全滅していた原因は、Dependabot 起動の workflow に Actions secrets が渡らない GitHub の仕様（Dependabot 用の secrets ストアが別）で、`MICROCMS_API_KEY` / `MICROCMS_SERVICE_DOMAIN` を Dependabot secrets 側に登録して解消済み。

その上で、次の 2 本は上流が eslint 10 / typescript 7 に追いついておらず、PR を開いても必ず落ちる状態だった。

| PR | 失敗内容 | 原因 |
|---|---|---|
| #21 eslint 10.8.0 | `TypeError: contextOrFilename.getFilename is not a function` | eslint-config-next が同梱する eslint-plugin-react 7.37.5 の peer は eslint `^9.7` まで |
| #24 typescript 7.0.2 | `npm error ERESOLVE` | @typescript-eslint 8.x の peer が typescript `>=4.8.4 <6.1.0` |

#21 は typescript-eslint を 8.66.0（eslint 10 対応済み）に上げても eslint-plugin-react で落ちることを worktree で確認済み。手元で回避する手段がないため、上流待ちとして ignore する。

## 変更

`.github/dependabot.yml` の npm エントリに `ignore` を追加。解除条件をコメントで残した。

- eslint `>=10`: eslint-plugin-react の peerDependencies に eslint 10 が入ったら外す
- typescript `>=7`: typescript-eslint が typescript 7 対応版を出したら外す

マージ後に #21 / #24 を close する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014noEXWC5Bi7eFn3GvNKBnz